### PR TITLE
Remove 'TORCH_COMPILE_DISABLE=1' and redirect MIOpen cache in LUMI vLLM scripts

### DIFF
--- a/run-vllm-lumi16.sh
+++ b/run-vllm-lumi16.sh
@@ -26,8 +26,6 @@ module load lumi-aif-singularity-bindings
 # Where to store the huge models. Point this to your project's scratch directory.
 export HF_HOME=/scratch/$SLURM_JOB_ACCOUNT/hf-cache/
 
-export TORCH_COMPILE_DISABLE=1
-
 export MASTER_ADDR=${MASTER_ADDR:-$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)}
 export MASTER_PORT=${MASTER_PORT:-9999}
 

--- a/run-vllm-lumi4.sh
+++ b/run-vllm-lumi4.sh
@@ -8,6 +8,11 @@
 #SBATCH --nodes 1
 #SBATCH --mem 240G
 
+# Set MIOPEN temp folder to avoid collisions with other users on the same node
+MIOPEN_DIR=$(mktemp -d)
+export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
+export MIOPEN_USER_DB=$MIOPEN_DIR/config
+
 # We use the PyTorch container provided by the LUMI AI Factory Services, which contains vLLM.
 export CONTAINER_IMAGE=/appl/local/laifs/containers/lumi-multitorch-latest.sif
 module use /appl/local/laifs/modules
@@ -15,9 +20,6 @@ module load lumi-aif-singularity-bindings
 
 # Where to store the huge models. Point this to your project's scratch directory.
 export HF_HOME=/scratch/$SLURM_JOB_ACCOUNT/hf-cache/
-
-# Torch compilation currently fails in the container, so we disable it here.
-export TORCH_COMPILE_DISABLE=1
 
 # The default parallelisation options applied by the run_vllm_process script will apply 4-fold tensor parallelism,
 # which is fine for this, so we don't need to provide any options here except for the model name.

--- a/run-vllm-process.sh
+++ b/run-vllm-process.sh
@@ -26,9 +26,6 @@ if [[ -z "$MODEL_NAME" ]]; then
     exit 1
 fi
 
-# note: vLLM will error if HIP_VISIBLE_DEVICES is not set but ROCR_VISIBLE_DEVICES is
-export HIP_VISIBLE_DEVICES=$ROCR_VISIBLE_DEVICES
-
 # if more than one node is requested, we configure vllm multi-node command line arguments
 MULTINODE_ARGS=""
 if [[ "$SLURM_NNODES" -gt 1 ]]; then

--- a/run-vllm-process.sh
+++ b/run-vllm-process.sh
@@ -26,6 +26,9 @@ if [[ -z "$MODEL_NAME" ]]; then
     exit 1
 fi
 
+# note: vLLM will error if HIP_VISIBLE_DEVICES is not set but ROCR_VISIBLE_DEVICES is
+export HIP_VISIBLE_DEVICES=$ROCR_VISIBLE_DEVICES
+
 # if more than one node is requested, we configure vllm multi-node command line arguments
 MULTINODE_ARGS=""
 if [[ "$SLURM_NNODES" -gt 1 ]]; then


### PR DESCRIPTION
Remove unnecessary "TORCH_COMPILE_DISABLE=1" and redirect MIOpen cache to avoid collisions with other users on the same node
(only in LUMI vLLM scripts)